### PR TITLE
Support rehosting at app.icontact.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: ruby
 rvm:
   - 2.3
   - 2.6
-before_install:
-  - gem update --system
-  - gem install bundler -v '< 2'
-  - gem uninstall bundler -v '>= 2'
 script: bundle exec rake
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.0 (2019-12)
+
+- Support multiple sessions with both new and legacy hosts (app.icontact.com or api.invoc.us).
+
 # v0.1.0 (2016-05-15)
 
 - Initial version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,6 @@ following details what you need to know in order to contribute.
 - Follow these [Code Review Styles](https://github.com/bkuhlmann/style_guides/blob/master/programming/code_reviews.md).
 - Follow these [Git Styles](https://github.com/bkuhlmann/style_guides/blob/master/programming/git.md).
 - Follow these [Bash Styles](https://github.com/bkuhlmann/style_guides/blob/master/programming/languages/bash.md).
-- Follow these [CSS Styles](https://github.com/bkuhlmann/style_guides/blob/master/programming/languages/css.md).
 - Follow these [Ruby Styles](https://github.com/bkuhlmann/style_guides/blob/master/programming/languages/ruby/ruby.md).
 
 # Contributing Code
@@ -31,5 +30,4 @@ following details what you need to know in order to contribute.
 
 # Feedback
 
-Expect a response within one to three business days.
 Changes, alternatives, and/or improvements might be suggested upon review.

--- a/README.md
+++ b/README.md
@@ -18,21 +18,32 @@ And then execute:
 
     $ bundle
 
+## Requirements
+
+iContact account, AppID and credentials, see the [iContact API Getting Started Guide](https://www.icontact.com/developerportal/documentation/start-building).
+
 ## Usage
 
-Example:
+Configure a connection and connect to the account:
 
-```
+```ruby
 	Pocus::Session.config(credentials)
 	Pocus::Session.instance.logger = Rails.logger
 	account = Pocus::Account.new(account_id: account_id)
+```
+
+Navigate and update entities:
+
+```ruby
 	folder = acount.clientfolders.find(folder_id)
 	folder.contacts.create(contacts_data)
 ```
 
+See the specs for sample code.
+
 ## Tests
 
-To run the tests you will need your own iContact account with a test folder.  Set the following environment variables:
+To run the tests you will need your own iContact account with a test folder (name: 'My First List').  Set the following environment variables:
 
 ```
 POCUS_APP_ID=0b34...b478c

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ iContact account, AppID and credentials, see the [iContact API Getting Started G
 Configure a connection and connect to the account:
 
 ```ruby
-    credentials = { host: 'icontact.com', app_id: a, username: u, password: p }
+    credentials = { host: 'app.icontact.com', app_id: a, username: u, password: p }
     session = Pocus::Session.new(credentials)
     session.logger = Rails.logger
 	account = Pocus::Account.new(session: session, account_id: account_id)

--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ iContact account, AppID and credentials, see the [iContact API Getting Started G
 Configure a connection and connect to the account:
 
 ```ruby
-	Pocus::Session.config(credentials)
-	Pocus::Session.instance.logger = Rails.logger
-	account = Pocus::Account.new(account_id: account_id)
+    credentials = { host: 'icontact.com', app_id: a, username: u, password: p }
+    session = Pocus::Session.new(credentials)
+    session.logger = Rails.logger
+	account = Pocus::Account.new(session: session, account_id: account_id)
 ```
 
 Navigate and update entities:

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "pocus"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/lib/pocus/account.rb
+++ b/lib/pocus/account.rb
@@ -4,5 +4,6 @@ module Pocus
     self.primary_key = :account_id
 
     has_many :clientfolders, path: '/c', class: 'ClientFolder'
+    has_many :users, class: 'User'
   end
 end

--- a/lib/pocus/account.rb
+++ b/lib/pocus/account.rb
@@ -3,6 +3,7 @@ module Pocus
     self.path = :a
     self.primary_key = :account_id
 
+    attr_accessor :session
     has_many :clientfolders, path: '/c', class: 'ClientFolder'
     has_many :users, class: 'User'
   end

--- a/lib/pocus/association.rb
+++ b/lib/pocus/association.rb
@@ -28,6 +28,10 @@ module Pocus
       owner.get("#{path}/#{id}", klass)
     end
 
+    def find_or_create_by(attributes)
+      where(attributes).first || create(attributes)
+    end
+
     def where(filters)
       owner.get_multiple(path, klass, filters)
     end

--- a/lib/pocus/client_folder.rb
+++ b/lib/pocus/client_folder.rb
@@ -9,6 +9,5 @@ module Pocus
     has_many :customfields, class: 'CustomField'
     has_many :segments, class: 'Segment'
     has_many :subscriptions, class: 'Subscription'
-    has_many :users, class: 'User'
   end
 end

--- a/lib/pocus/resource.rb
+++ b/lib/pocus/resource.rb
@@ -119,7 +119,7 @@ module Pocus
     end
 
     def session
-      Session.instance
+      parent.session
     end
 
     def marshal_dump

--- a/lib/pocus/session.rb
+++ b/lib/pocus/session.rb
@@ -69,13 +69,17 @@ module Pocus
     end
 
     def log_request_response(uri, method, data)
-      logger.info "request = #{method} #{uri}#{data ? '?' + data : ''}"
+      logger.info  "[#{self.class.name}] request = #{method} #{uri}#{data ? '?' + data : ''}"
       response = nil
       tms = Benchmark.measure do
         response = yield uri, method, data
       end
-      logger.info("API response (#{tms.real}s): #{response.inspect} #{response.body}")
+      logger.info  "[#{self.class.name}] response (#{ms(tms)}ms): #{response.inspect} #{response.body}"
       response
+    end
+
+    def ms(tms)
+      (tms.real*1000).round(3)
     end
   end
 end

--- a/lib/pocus/session.rb
+++ b/lib/pocus/session.rb
@@ -29,14 +29,6 @@ module Pocus
       @logger = logger
     end
 
-    def self.config(options = {})
-      @config = options
-    end
-
-    def self.instance
-      @instance ||= new(@config)
-    end
-
     # Accepts hash of fields to send.
     # Returns parsed response body, always a hash.
     def send_request(method, path, fields = {})

--- a/lib/pocus/session.rb
+++ b/lib/pocus/session.rb
@@ -16,11 +16,12 @@ module Pocus
 
   # Sends authenticated JSON requests to remote service using HTTPS.
   class Session
-    BASE_URL = 'https://api.invoc.us/icp'.freeze
+    attr_reader :base_url
     attr_reader :credentials
     attr_accessor :logger
 
-    def initialize(app_id: '', username: '', password: '', logger: Logger.new('/dev/null'))
+    def initialize(host: 'api.invoc.us', app_id:, username:, password:, logger: Logger.new('/dev/null'))
+      @base_url = "https://#{host}/icp".freeze
       @credentials = {
         'API-AppId'    => app_id,
         'API-Username' => username,
@@ -29,10 +30,15 @@ module Pocus
       @logger = logger
     end
 
+    # 'Pro' is legacy as moniker dropped.
+    def pro?
+      base_url =~ /invoc.us/
+    end
+
     # Accepts hash of fields to send.
     # Returns parsed response body, always a hash.
     def send_request(method, path, fields = {})
-      response = send_logged_request(URI(BASE_URL + path), method, request_data(fields))
+      response = send_logged_request(URI(base_url + path), method, request_data(fields))
       fail UnexpectedHttpResponse, response unless response.is_a? Net::HTTPSuccess
       JSON.parse(response.body)
     end

--- a/pocus.gemspec
+++ b/pocus.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rake', '~> 11.0'
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'pry-state'
   spec.add_development_dependency 'rspec', '~> 3.4'
 

--- a/spec/lib/pocus/account_spec.rb
+++ b/spec/lib/pocus/account_spec.rb
@@ -27,7 +27,10 @@ RSpec.describe Pocus::Account do
 
   describe '.associations' do
     it 'stores configuration options' do
-      expect(Pocus::Account.associations).to eq Hash[clientfolders: {path: '/c', class: 'ClientFolder'}]
+      expect(Pocus::Account.associations).to eq Hash[
+        clientfolders: {path: '/c', class: 'ClientFolder'},
+        users: {class: 'User'},
+      ]
       expect(Pocus::Account.new({}).clientfolders).to be_kind_of(Pocus::Association)
     end
   end

--- a/spec/lib/pocus/account_spec.rb
+++ b/spec/lib/pocus/account_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 include Pocus::Fixtures
 
 RSpec.describe Pocus::Account do
-  Pocus::Session.config(fixtures(:credentials))
-  Pocus::Session.instance.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG']
-  let(:account) { Pocus::Account.new(account_id: fixtures(:account_id)) }
+  let(:session) { Pocus::Session.new(fixtures :credentials) }
+  before { session.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG'] }
+  let(:account) { Pocus::Account.new(session: session, account_id: fixtures(:account_id)) }
   let(:test_folder) { account.clientfolders.find(fixtures(:test_client_folder_id)) }
   let(:folder_attributes) do
     {

--- a/spec/lib/pocus/client_folder_spec.rb
+++ b/spec/lib/pocus/client_folder_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Pocus::ClientFolder do
       from_name: 'John Smith',
       from_last_name: 'Smith',
       from_email: 'smith@icontact.com',
-      business_name: 'Example Corp',
       street: '2635 Meridian Parkway',
       city: 'Durham',
       state: 'NC',
@@ -28,12 +27,14 @@ RSpec.describe Pocus::ClientFolder do
 
   describe '#post' do
     it 'updates a client folder' do
+      skip unless session.pro?
       new_name = rand.to_s
-      test_folder.business_name = new_name
+      test_folder.from_name = new_name
 
       response = test_folder.post
+      expect(response.errors).to be_empty
       expect(response.warnings).to be_empty
-      expect(response.business_name).to eq new_name
+      expect(response.from_name).to eq new_name
     end
 
     it 'handles errors' do

--- a/spec/lib/pocus/client_folder_spec.rb
+++ b/spec/lib/pocus/client_folder_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 include Pocus::Fixtures
 
 RSpec.describe Pocus::ClientFolder do
-  Pocus::Session.config(fixtures(:credentials))
-  Pocus::Session.instance.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG']
-  let(:account) { Pocus::Account.new(account_id: fixtures(:account_id)) }
+  let(:session) { Pocus::Session.new(fixtures :credentials) }
+  before { session.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG'] }
+  let(:account) { Pocus::Account.new(session: session, account_id: fixtures(:account_id)) }
   let(:test_folder) { account.clientfolders.find(fixtures(:test_client_folder_id)) }
   let(:folder_attributes) do
     {

--- a/spec/lib/pocus/client_folder_spec.rb
+++ b/spec/lib/pocus/client_folder_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Pocus::ClientFolder do
   describe '#post' do
     it 'updates a client folder' do
       skip unless session.pro?
-      new_name = rand.to_s
+      new_name = random_name(12)
       test_folder.from_name = new_name
 
       response = test_folder.post

--- a/spec/lib/pocus/contact_spec.rb
+++ b/spec/lib/pocus/contact_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 include Pocus::Fixtures
 
 RSpec.describe Pocus::Contact do
-  Pocus::Session.config(fixtures(:credentials))
-  Pocus::Session.instance.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG']
-  let(:account) { Pocus::Account.new(account_id: fixtures(:account_id)) }
+  let(:session) { Pocus::Session.new(fixtures :credentials) }
+  before { session.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG'] }
+  let(:account) { Pocus::Account.new(session: session, account_id: fixtures(:account_id)) }
   let(:test_folder) { account.clientfolders.find(fixtures(:test_client_folder_id)) }
   let(:contact_attributes) do
     {

--- a/spec/lib/pocus/contact_spec.rb
+++ b/spec/lib/pocus/contact_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Pocus::Contact do
         contact_attributes.dup.merge(email: "#{i}@dummy.com")
       end
       response = test_folder.contacts.create(fields_multiple)
-      expect(response.warnings.count).to be > 1
+      expect(response.warnings.count).to be >= 1
       contact = response.first
       expect(contact).to be_kind_of(Pocus::Contact)
       expect(contact.contact_id).to match(/^\d+$/)

--- a/spec/lib/pocus/contact_spec.rb
+++ b/spec/lib/pocus/contact_spec.rb
@@ -71,10 +71,11 @@ RSpec.describe Pocus::Contact do
     it 'deletes a contact' do
       contact = test_folder.contacts.create(email: 'delete.me@example.com')
       expect(contact.destroy).to be true
-      expect do
-        contact.reload
+      if session.pro?
+        expect { contact.reload }.to raise_error(/404/)
+      else
+        expect(contact.reload.status).to eq 'deleted'
       end
-        .to raise_error(/404/)
     end
   end
 end

--- a/spec/lib/pocus/custom_field_spec.rb
+++ b/spec/lib/pocus/custom_field_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Pocus::CustomField do
   describe '#custom_fields.create' do
     it 'creates custom fields' do
       birthdate_fields = {
-        private_name: rand.to_s,
+        private_name: random_name(12),
         field_type: :date,
         display_to_user: 1
       }

--- a/spec/lib/pocus/custom_field_spec.rb
+++ b/spec/lib/pocus/custom_field_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 include Pocus::Fixtures
 
 RSpec.describe Pocus::CustomField do
-  Pocus::Session.config(fixtures(:credentials))
-  Pocus::Session.instance.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG']
-  let(:account) { Pocus::Account.new(account_id: fixtures(:account_id)) }
+  let(:session) { Pocus::Session.new(fixtures :credentials) }
+  before { session.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG'] }
+  let(:account) { Pocus::Account.new(session: session, account_id: fixtures(:account_id)) }
   let(:test_folder) { account.clientfolders.find(fixtures(:test_client_folder_id)) }
 
   describe '#custom_fields.create' do

--- a/spec/lib/pocus/custom_field_spec.rb
+++ b/spec/lib/pocus/custom_field_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Pocus::CustomField do
   describe '#custom_fields.create' do
     it 'creates custom fields' do
       birthdate_fields = {
-        custom_field_id: :birthdate,
+        private_name: rand.to_s,
         field_type: :date,
         display_to_user: 1
       }
@@ -21,6 +21,7 @@ RSpec.describe Pocus::CustomField do
       expect(custom_field).to be_a(Pocus::CustomField)
       expect(custom_field.errors).to be_empty
       expect(custom_field.warnings).to be_empty
+      custom_field.destroy
     end
   end
 end

--- a/spec/lib/pocus/list_spec.rb
+++ b/spec/lib/pocus/list_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Pocus::List do
 
   describe 'lists.where' do
     before do
-      @lists = test_folder.lists.create(name: "Random list #{rand(10**6)}")
+      @lists = test_folder.lists.create(name: "Random list #{random_name(12)}")
     end
 
     after do

--- a/spec/lib/pocus/list_spec.rb
+++ b/spec/lib/pocus/list_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 include Pocus::Fixtures
 
 RSpec.describe Pocus::List do
-  Pocus::Session.config(fixtures(:credentials))
-  Pocus::Session.instance.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG']
-  let(:account) { Pocus::Account.new(account_id: fixtures(:account_id)) }
+  let(:session) { Pocus::Session.new(fixtures :credentials) }
+  before { session.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG'] }
+  let(:account) { Pocus::Account.new(session: session, account_id: fixtures(:account_id)) }
   let(:test_folder) { account.clientfolders.find(fixtures(:test_client_folder_id)) }
 
   describe 'lists.all' do
@@ -44,7 +44,7 @@ RSpec.describe Pocus::List do
     end
 
     it 'handles errors' do
-      Pocus::Session.instance.logger = Logger.new(STDOUT)
+      session.logger = Logger.new(STDOUT)
       response = test_folder.lists.where(invalid_key: 'My First List')
       pending 'API bug, does not always include warning!'
       expect(response.warnings.count).to be > 1

--- a/spec/lib/pocus/segment_criteria_spec.rb
+++ b/spec/lib/pocus/segment_criteria_spec.rb
@@ -9,15 +9,16 @@ RSpec.describe Pocus::SegmentCriteria do
   Pocus::Session.instance.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG']
   let(:account) { Pocus::Account.new(account_id: fixtures(:account_id)) }
   let(:test_folder) { account.clientfolders.find(fixtures(:test_client_folder_id)) }
+  let(:list) { test_folder.lists.find_or_create_by(name: 'My First List') }
 
   describe '#criteria.create' do
     it 'creates segment criteria' do
-      list = test_folder.lists.where(name: 'My First List').first
       segment = test_folder.segments.create(name: 'Contacts in North Carolina', list_id: list.id)
       criteria = segment.criteria.create(field_name: 'state', operator: :eq, values: ['North Carolina'])
       expect(criteria).to be_a(Pocus::SegmentCriteria)
       expect(criteria.errors).to be_empty
       expect(criteria.warnings).to be_empty
+      expect(segment.destroy).to be true
     end
   end
 end

--- a/spec/lib/pocus/segment_criteria_spec.rb
+++ b/spec/lib/pocus/segment_criteria_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 include Pocus::Fixtures
 
 RSpec.describe Pocus::SegmentCriteria do
-  Pocus::Session.config(fixtures(:credentials))
-  Pocus::Session.instance.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG']
-  let(:account) { Pocus::Account.new(account_id: fixtures(:account_id)) }
+  let(:session) { Pocus::Session.new(fixtures :credentials) }
+  before { session.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG'] }
+  let(:account) { Pocus::Account.new(session: session, account_id: fixtures(:account_id)) }
   let(:test_folder) { account.clientfolders.find(fixtures(:test_client_folder_id)) }
   let(:list) { test_folder.lists.find_or_create_by(name: 'My First List') }
 

--- a/spec/lib/pocus/segment_spec.rb
+++ b/spec/lib/pocus/segment_spec.rb
@@ -9,13 +9,14 @@ RSpec.describe Pocus::Segment do
   Pocus::Session.instance.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG']
   let(:account) { Pocus::Account.new(account_id: fixtures(:account_id)) }
   let(:test_folder) { account.clientfolders.find(fixtures(:test_client_folder_id)) }
+  let(:list) { test_folder.lists.find_or_create_by(name: 'My First List') }
 
   describe '#segments.create' do
-    it 'creates segments' do
-      list = test_folder.lists.where(name: 'My First List').first
+    it 'creates and deletes segments' do
       segment = test_folder.segments.create(name: 'Contacts in North Carolina', list_id: list.id)
       expect(segment).to be_kind_of(Pocus::Segment)
       expect(segment.id).to match(/^\d+$/)
+      expect(segment.destroy).to be true
     end
   end
 end

--- a/spec/lib/pocus/segment_spec.rb
+++ b/spec/lib/pocus/segment_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 include Pocus::Fixtures
 
 RSpec.describe Pocus::Segment do
-  Pocus::Session.config(fixtures(:credentials))
-  Pocus::Session.instance.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG']
-  let(:account) { Pocus::Account.new(account_id: fixtures(:account_id)) }
+  let(:session) { Pocus::Session.new(fixtures :credentials) }
+  before { session.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG'] }
+  let(:account) { Pocus::Account.new(session: session, account_id: fixtures(:account_id)) }
   let(:test_folder) { account.clientfolders.find(fixtures(:test_client_folder_id)) }
   let(:list) { test_folder.lists.find_or_create_by(name: 'My First List') }
 

--- a/spec/lib/pocus/subscription_spec.rb
+++ b/spec/lib/pocus/subscription_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Pocus::Subscription do
   describe '#subscriptions.create' do
     it 'creates multiple subscriptions' do
       fields_multiple = (1..3).map do |_i|
-        contact_attributes.dup.merge(email: "#{rand(10**6)}@dummy.com")
+        contact_attributes.dup.merge(email: "#{random_name(8)}@dummy.com")
       end
       contacts = test_folder.contacts.create(fields_multiple)
       subscription_fields = contacts.map do |contact|

--- a/spec/lib/pocus/subscription_spec.rb
+++ b/spec/lib/pocus/subscription_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 include Pocus::Fixtures
 
 RSpec.describe Pocus::Subscription do
-  Pocus::Session.config(fixtures(:credentials))
-  Pocus::Session.instance.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG']
-  let(:account) { Pocus::Account.new(account_id: fixtures(:account_id)) }
+  let(:session) { Pocus::Session.new(fixtures :credentials) }
+  before { session.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG'] }
+  let(:account) { Pocus::Account.new(session: session, account_id: fixtures(:account_id)) }
   let(:test_folder) { account.clientfolders.find(fixtures(:test_client_folder_id)) } # frozen_string_literal: true
   let(:test_list) { test_folder.lists.find_or_create_by(name: 'My First List') }
   let(:contact_attributes) do

--- a/spec/lib/pocus/subscription_spec.rb
+++ b/spec/lib/pocus/subscription_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Pocus::Subscription do
   Pocus::Session.instance.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG']
   let(:account) { Pocus::Account.new(account_id: fixtures(:account_id)) }
   let(:test_folder) { account.clientfolders.find(fixtures(:test_client_folder_id)) } # frozen_string_literal: true
-  let(:test_list) { test_folder.lists.where(name: 'My First List').first }
+  let(:test_list) { test_folder.lists.find_or_create_by(name: 'My First List') }
   let(:contact_attributes) do
     {
       prefix: 'Miss',

--- a/spec/lib/pocus/user_spec.rb
+++ b/spec/lib/pocus/user_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 include Pocus::Fixtures
 
 RSpec.describe Pocus::User do
-  Pocus::Session.config(fixtures(:credentials))
-  Pocus::Session.instance.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG']
-  let(:account) { Pocus::Account.new(account_id: fixtures(:account_id)) }
+  let(:session) { Pocus::Session.new(fixtures :credentials) }
+  before { session.logger = Logger.new(STDOUT) if ENV['POCUS_DEBUG'] }
+  let(:account) { Pocus::Account.new(session: session, account_id: fixtures(:account_id)) }
   let(:test_folder) { account.clientfolders.find(fixtures(:test_client_folder_id)) }
 
   describe '#users.all' do

--- a/spec/lib/pocus/user_spec.rb
+++ b/spec/lib/pocus/user_spec.rb
@@ -12,25 +12,25 @@ RSpec.describe Pocus::User do
 
   describe '#users.all' do
     it 'fetches users' do
-      users = test_folder.users.all
+      users = account.users.all
       expect(users.first).to be_kind_of(Pocus::User)
-      expect(users.first.id).to be_a(Integer)
+      expect(users.first.id.to_i).to be_a(Integer)
     end
   end
 
   describe '#reload' do
     it 'fetches user details' do
-      users = test_folder.users.all
+      users = account.users.all
       user = users.sample
 
       user.reload
-      expect(user.id).to be_a(Integer)
+      expect(user.id.to_i).to be_a(Integer)
     end
   end
 
   describe '#permissions.all' do
     it 'fetches permissions' do
-      permissions = test_folder.users.all.sample.permissions.all
+      permissions = account.users.all.sample.permissions.all
       expect(permissions.first).to be_kind_of(Pocus::Permission)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ module Pocus
       case key
       when :credentials
         {
+          host: ENV.fetch('POCUS_HOSTNAME', 'api.invoc.us'),
           app_id: ENV.fetch('POCUS_APP_ID'),
           username: ENV.fetch('POCUS_USERNAME'),
           password: ENV.fetch('POCUS_PASSWORD')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,5 +27,10 @@ module Pocus
         ENV.fetch('POCUS_TEST_CLIENT_FOLDER')
       end
     end
+
+    def random_name(length)
+      charset = Array('A'..'Z') + Array('a'..'z')
+      Array.new(length) { charset.sample }.join
+    end
   end
 end

--- a/spec/support/extensions/pry.rb
+++ b/spec/support/extensions/pry.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 require 'pry'
-require 'pry-byebug'
 require 'pry-state'


### PR DESCRIPTION
iContact has been sold from Cision to j2 resulting in all customers being migrated from api.invoc.us to app.icontact.com with some accompanying minor changes to the API.